### PR TITLE
Ensure dbReads respect list order.

### DIFF
--- a/xchdb/Tools/Db/Core.hs
+++ b/xchdb/Tools/Db/Core.hs
@@ -31,6 +31,8 @@ module Tools.Db.Core
           , dbMv
           ) where
 
+import Data.List
+import Data.Function
 import Control.Applicative
 import Control.Monad
 import Control.Monad.Error
@@ -64,7 +66,9 @@ dbExists = call comCitrixXenclientDbExists
 
 -- List child paths of a given node
 dbListPaths :: (MonadRpc e m) => Path -> m [Path]
-dbListPaths path = map prefixPath <$> dbList path
+dbListPaths path = do 
+    paths <- dbList path 
+    return $ map prefixPath (sortBy (compare `on` (read :: String->Int)) paths)
   where prefixPath y = path ++ "/" ++ y
 
 -- Remove a node with subnodes


### PR DESCRIPTION
On dbReads for lists, make sure we sort by the ids written
with each entry.  This guarantees reads come back in the same
order the write was made, to handle the lack of ordering in a
JSON scheme.  This fix is for improper vm autostarting, but
is relevant for any toolstack dbRead using lists.

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>