### PR TITLE
Fix vasprintf typo in libxcxenstore

### DIFF
--- a/xcxenstore/src/xcxenstore.c
+++ b/xcxenstore/src/xcxenstore.c
@@ -257,7 +257,7 @@ bool vxenstore_chmod (const char *perms, unsigned int nbperm,
     if (!xs_strings_to_perms (p, nbperm, perms))
         goto xs_chmod_err;
 
-    if (!vasprintf (&buff, format, arg) == -1)
+    if (vasprintf (&buff, format, arg) == -1)
         goto xs_chmod_err;
 
     ret = xs_set_permissions (xs, xs_transaction, buff, p, nbperm);


### PR DESCRIPTION
Move the patch from layer to the repo. 
OXT-802

https://github.com/OpenXT/xenclient-oe/pull/465
