### PR TITLE
x86_64: [xclibs] Make sure foreign calls use 64 types

### DIFF
--- a/xchv4v/Tools/V4V.hsc
+++ b/xchv4v/Tools/V4V.hsc
@@ -80,8 +80,8 @@ foreign import ccall "libv4v.h v4v_bind" c_v4v_bind        :: CInt -> Ptr Addr -
 foreign import ccall "libv4v.h v4v_connect" c_v4v_connect  :: CInt -> Ptr Addr -> IO CInt
 foreign import ccall "libv4v.h v4v_listen" c_v4v_listen    :: CInt -> CInt -> IO CInt
 foreign import ccall "libv4v.h v4v_accept" c_v4v_accept    :: CInt -> Ptr Addr -> IO CInt
-foreign import ccall "libv4v.h v4v_send" c_v4v_send        :: CInt -> Ptr Word8 -> CUInt -> CInt -> IO CInt
-foreign import ccall "libv4v.h v4v_recv" c_v4v_recv        :: CInt -> Ptr Word8 -> CUInt -> CInt -> IO CInt
+foreign import ccall "libv4v.h v4v_send" c_v4v_send        :: CInt -> Ptr Word8 -> CULong -> CInt -> IO CLong
+foreign import ccall "libv4v.h v4v_recv" c_v4v_recv        :: CInt -> Ptr Word8 -> CULong -> CInt -> IO CLong
 foreign import ccall "libv4v.h v4v_getsockopt" c_v4v_getsockopt :: CInt -> CInt -> CInt -> Ptr () -> Ptr Int -> IO Int
 
 int :: (Integral a, Num b) => a -> b


### PR DESCRIPTION
  Size_t and ssize_t are used in foreign C code, which
  are 64 bits on x64.  In Haskell, Int is still 32 bits on
  x64, so use CLong and CULong for proper bit length.

  OXT-1476 OXT-1528

Signed-off-by: Chris <rogersc@ainfosec.com>