### PR TITLE
xcxenstore: Check vasprintf return value

### DIFF
--- a/xcxenstore/src/xcxenstore.c
+++ b/xcxenstore/src/xcxenstore.c
@@ -162,7 +162,9 @@ char **vxenstore_ls (unsigned int *num, const char *format, va_list arg)
 
     assert (xs != NULL);
 
-    vasprintf (&buff, format, arg);
+    if (vasprintf (&buff, format, arg) == -1)
+        return NULL;
+
     ret = xs_directory (xs, xs_transaction, buff, num);
     free_no_errno (buff);
 


### PR DESCRIPTION
Fix vasprintf warn_unused_result error:

xcxenstore.c: In function 'vxenstore_ls':
xcxenstore.c:165:5: error: ignoring return value of 'vasprintf', declared with attribute warn_unused_result [-Werror=unused-result]
     vasprintf (&buff, format, arg);

OXT-1698

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>