### PR TITLE
RFC: xchdb: Use rpc-autogen bindings module

### DIFF
--- a/xchdb/xchdb.cabal
+++ b/xchdb/xchdb.cabal
@@ -17,12 +17,12 @@ library
     containers,
     json,
     xchutils,
-    xch-rpc
+    xch-rpc,
+    rpc-autogen
 
   exposed-modules:
     Tools.Db
 
   other-modules:
-    Rpc.Autogen.DbClient
     Tools.Db.Core
     Tools.Db.Marshall


### PR DESCRIPTION
dbus-gen generates a set of bindings for the currently supported API. Use the built module instead of relying on generating the bindings from the IDL in the source tree.