### PR TITLE
OXT-1824 [rpc] Export new function getConn

### DIFF
--- a/xch-rpc/Rpc/Core.hs
+++ b/xch-rpc/Rpc/Core.hs
@@ -66,6 +66,7 @@ module Rpc.Core
            , systemBus
            , sessionBus
            , connectBus
+           , getConn
            ) where
 
 import Prelude hiding (catch)

--- a/xch-rpc/Rpc/Dispatch.hs
+++ b/xch-rpc/Rpc/Dispatch.hs
@@ -33,6 +33,7 @@ module Rpc.Dispatch
        , hookSignalFrom
        , requestName
        , releaseName
+       , getConn
        ) where
 
 import Control.Concurrent
@@ -458,3 +459,6 @@ msgHello
             , callInterfaceT = fromString "org.freedesktop.DBus"
             , callMemberT = fromString "Hello"
             , callArgs = [ ] }
+
+getConn :: Dispatcher -> D.DBusContext
+getConn d = conn d


### PR DESCRIPTION
  This gives us a handle into the lower level Rpc library
  to retrieve the DBusContext stored in a Dispatcher object.
  This is a necessary argument for closing a DBusTransport to
  avoid leaking FDs.

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>